### PR TITLE
DDP-5106 | mobile select dsm realm bug

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,7 +8,7 @@
           <b>Select realm</b>
           <span class="caret"></span>
         </a>
-        <ul class="dropdown-menu" [ngModel]="getAuth().selectedRealm"  >
+        <ul class="dropdown-menu">
           <li *ngFor="let realms of getAuth().realmList"> <a (click)="selectRealmAndDoNothing(realms.name)"> {{realms.value}} </a> </li>          
         </ul>
           <!-- <span class="Menu--Select"><b>Select realm: </b>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,15 +9,8 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
-          <li *ngFor="let realms of getAuth().realmList"> <a (click)="selectRealmAndDoNothing(realms.name)"> {{realms.value}} </a> </li>          
+          <li *ngFor="let realms of getAuth().realmList" [ngClass]="{'active': isRealmChosen(realms.name)}"> <a (click)="selectRealmAndDoNothing(realms.name)"> {{realms.value}} </a> </li>          
         </ul>
-          <!-- <span class="Menu--Select"><b>Select realm: </b>
-          </span>
-          <select [ngModel]="getAuth().selectedRealm" class="SelectText"
-                  (click)="getAuth().getRealmList()" (ngModelChange)="getAuth().selectRealm($event)">
-            <option value="" selected>Please Select</option>
-            <option *ngFor="let realms of getAuth().realmList" [value]="realms.name">{{realms.value}}</option>
-          </select> -->
       </li>
       <li class="dropdown" *ngIf="getAuth().authenticated()
         && (hasRole().allowToViewSampleLists() || hasRole().allowedToHandleSamples() || hasRole().allowedToViewReceivingPage() || hasRole().allowedToDiscardSamples() || hasRole().allowedToExitParticipant())">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,16 +3,21 @@
 <nav class="navbar navbar-inverse">
   <div class="container-fluid">
     <ul class="nav navbar-nav">
-      <li class="Float--left" *ngIf="getAuth().authenticated() && shouldSeeRealmSelection()">
-        <div class="Float--left">
-          <p class="Menu--Select"><b>Select realm: </b>
-            <select [ngModel]="getAuth().selectedRealm" class="SelectText"
-                    (click)="getAuth().getRealmList()" (ngModelChange)="getAuth().selectRealm($event)">
-              <option value="" selected>Please Select</option>
-              <option *ngFor="let realms of getAuth().realmList" [value]="realms.name">{{realms.value}}</option>
-            </select>
-          </p>
-        </div>
+      <li class="dropdown" *ngIf="getAuth().authenticated() && shouldSeeRealmSelection()">
+        <a class="dropdown-toggle" data-toggle="dropdown" href="#" (click)="getAuth().getRealmList()">
+          <b>Select realm</b>
+          <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu" [ngModel]="getAuth().selectedRealm"  >
+          <li *ngFor="let realms of getAuth().realmList"> <a (click)="selectRealmAndDoNothing(realms.name)"> {{realms.value}} </a> </li>          
+        </ul>
+          <!-- <span class="Menu--Select"><b>Select realm: </b>
+          </span>
+          <select [ngModel]="getAuth().selectedRealm" class="SelectText"
+                  (click)="getAuth().getRealmList()" (ngModelChange)="getAuth().selectRealm($event)">
+            <option value="" selected>Please Select</option>
+            <option *ngFor="let realms of getAuth().realmList" [value]="realms.name">{{realms.value}}</option>
+          </select> -->
       </li>
       <li class="dropdown" *ngIf="getAuth().authenticated()
         && (hasRole().allowToViewSampleLists() || hasRole().allowedToHandleSamples() || hasRole().allowedToViewReceivingPage() || hasRole().allowedToDiscardSamples() || hasRole().allowedToExitParticipant())">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,7 +28,7 @@ export class AppComponent implements OnInit {
 
   selectRealmAndDoNothing( newValue ) {
     this.auth.selectRealm(newValue);
-    return false;
+    this.doNothing();
   }
 
   doLogin() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit, ViewChild} from "@angular/core";
 import {MdMenuTrigger} from "@angular/material";
 import {DomSanitizer} from "@angular/platform-browser";
-import {Router} from "@angular/router";
+import {ActivatedRoute, Router} from "@angular/router";
 
 import {Auth} from "./services/auth.service";
 import {RoleService} from "./services/role.service";
@@ -12,14 +12,20 @@ import {ComponentService} from "./services/component.service";
   templateUrl: "./app.component.html"
 } )
 export class AppComponent implements OnInit {
-
+  private realmFromUrl: string;
   @ViewChild( MdMenuTrigger ) trigger: MdMenuTrigger;
 
-  constructor( private router: Router, private auth: Auth, private sanitizer: DomSanitizer, private role: RoleService ) {
+  constructor( private router: Router, private auth: Auth, private sanitizer: DomSanitizer, private role: RoleService
+    , private route: ActivatedRoute ) {
   }
 
   ngOnInit() {
     window.scrollTo( 0, 0 );
+    this.route.queryParams
+      .filter(params => params.realm)
+      .subscribe(params => {
+        this.realmFromUrl = params.realm;
+    });
   }
 
   doNothing() { //needed for the menu, otherwise page will refresh!
@@ -29,6 +35,10 @@ export class AppComponent implements OnInit {
   selectRealmAndDoNothing( newValue ) {
     this.auth.selectRealm(newValue);
     this.doNothing();
+  }
+
+  isRealmChosen( realm ) {
+    return this.realmFromUrl === realm;
   }
 
   doLogin() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,6 +26,11 @@ export class AppComponent implements OnInit {
     return false;
   }
 
+  selectRealmAndDoNothing( newValue ) {
+    this.auth.selectRealm(newValue);
+    return false;
+  }
+
   doLogin() {
     localStorage.removeItem( ComponentService.MENU_SELECTED_REALM ); //if user logs in new or logs out, remove stored menu!
     if (this.auth.authenticated()) {


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5106

Current picture: 

![mobile_select_realm_bug](https://user-images.githubusercontent.com/75846598/105869759-046e9a80-6011-11eb-8b4c-17a25c7aeee1.png)

Because of "Select realm" and "Samples" are overlapping to each other in mobile, it is impossible to choose the realm.

After changes:

![fixed_dsm_select](https://user-images.githubusercontent.com/75846598/105869921-31bb4880-6011-11eb-914b-fffd28857164.png)

**Things to pay attention:**

selectRealmAndDoNothing - method which updates realm on `<li>` click and restricts to reload the page.

isRealmChosen - method which helps to determine which realm is chosen thus selected realm is highlighted for user to easily understand which realm he/she uses.


