### PR TITLE
Check if externalOrderStatus is undefined in response, to see correct sample status

### DIFF
--- a/src/app/participant-list/models/sample.model.ts
+++ b/src/app/participant-list/models/sample.model.ts
@@ -35,7 +35,7 @@ export class Sample {
   }
 
   get sampleQueue() {
-    if (this.externalOrderStatus !== null) {
+    if (this.externalOrderStatus !== null && this.externalOrderStatus !== undefined) {
       return this.externalOrderStatus + " (GBF)";
     }
     if (this.deactivatedDate !== 0) {


### PR DESCRIPTION
Although in the backend externalOrderStatus was null in response we didn't have null fields, thus front-end saw it as undefined field not null.