### PR TITLE
DDP-5159 | added utility method to parse milliseconds to utc date

### DIFF
--- a/src/app/participant-list/participant-list.component.html
+++ b/src/app/participant-list/participant-list.component.html
@@ -272,7 +272,7 @@
                       <li class="LIST-SEPARATOR" *ngFor="let invite of pt.data.invitations">
                         <p class="BIT-OF-MARGIN" *ngIf="invite != null">
                           <ng-container *ngIf="col.type === 'DATE'">
-                            {{invite[col.participantColumn.name] | date:'medium'}}
+                            {{parseMillisToDateString(invite[col.participantColumn.name])}}
                           </ng-container>
                           <ng-container *ngIf="col.type === 'TEXT' && col.participantColumn.name !== 'guid'">
                             {{invite[col.participantColumn.name]}}

--- a/src/app/participant-list/participant-list.component.ts
+++ b/src/app/participant-list/participant-list.component.ts
@@ -776,6 +776,13 @@ export class ParticipantListComponent implements OnInit {
     this.getData();
   }
 
+  public parseMillisToDateString( dateInMillis: number ) : string {
+    const date = new Date(dateInMillis);
+    const options = {year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit', timeZone: 'UTC'};
+    const dateString = date.toLocaleString('en-US', options);
+    return dateString;
+  }
+
   public clearManualFilters() {
     this.dataSources.forEach( ( value: string, key: string ) => {
       if (this.selectedColumns[ key ] != null) {


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5159

**Changes have been done:**
Since in angular 4 Date pipe does not support timezone conversion, added utility method, which converts date represented in milliseconds to date string in UTC timezone, because, by default Date pipe uses client's timezone thus it will convert time to local timezone which may cause confusion