### PR TITLE
DDP-5615 | copy proband info to family member

### DIFF
--- a/src/app/popups/add-family-member/add-family-member.component.html
+++ b/src/app/popups/add-family-member/add-family-member.component.html
@@ -49,6 +49,16 @@
           </md-select>
         </td>
       </tr>
+
+      <tr>
+        <td><b>Copy Proband Info</b></td>
+        <td>
+          <md-checkbox
+          [(ngModel)]="isCopyProbandInfo"
+          [color]="'primary'">
+          </md-checkbox>
+        </td>
+      </tr>
   
       <tr>
         <td>

--- a/src/app/popups/add-family-member/add-family-member.component.ts
+++ b/src/app/popups/add-family-member/add-family-member.component.ts
@@ -17,6 +17,8 @@ export class AddFamilyMemberComponent implements OnInit {
   familyMemberFirstName: string;
   familyMemberLastName: string;
   familyMemberSubjectId: string;
+  chosenRelation: string;
+  isCopyProbandInfo: boolean = false;
   relations = [
     "Brother",
     "Daugther",
@@ -39,7 +41,6 @@ export class AddFamilyMemberComponent implements OnInit {
     "Sister",
     "Son"
   ]
-  chosenRelation: string;
 
   constructor(@Inject(MD_DIALOG_DATA) public data: {participant: any}, private dsmService: DSMService, 
               private compService: ComponentService, private role: RoleService, public dialog: MdDialog,
@@ -54,6 +55,7 @@ export class AddFamilyMemberComponent implements OnInit {
 
   submitFamilyMember() {
     let shortId = this.data.participant.data.profile["hruid"];
+    debugger;
     let payload = {
       participantGuid: this.data.participant.data.profile["guid"],
       realm: this.compService.getRealm(),
@@ -62,7 +64,8 @@ export class AddFamilyMemberComponent implements OnInit {
         lastName: this.familyMemberLastName,
         memberType: this.chosenRelation,
         familyId: shortId,
-        collaboratorParticipantId: shortId + "_" + this.familyMemberSubjectId
+        collaboratorParticipantId: shortId + "_" + this.familyMemberSubjectId,
+        copyProbandInfo: this.isCopyProbandInfo
       },
       userId: this.role.userID()
     }

--- a/src/app/popups/add-family-member/add-family-member.component.ts
+++ b/src/app/popups/add-family-member/add-family-member.component.ts
@@ -20,6 +20,7 @@ export class AddFamilyMemberComponent implements OnInit {
   familyMemberSubjectId: string;
   chosenRelation: string;
   isCopyProbandInfo: boolean = false;
+  probandDataId: number = this.getProbandDataId();
   isParticipantProbandEmpty: boolean = this.getProbandDataId() == null;
 
   constructor(@Inject(MD_DIALOG_DATA) public data: {participant: any}, private dsmService: DSMService, 
@@ -27,18 +28,23 @@ export class AddFamilyMemberComponent implements OnInit {
               private dialogRef: MdDialogRef<AddFamilyMemberComponent>) { }
 
   ngOnInit() {
-    this.dsmService.getParticipantData(this.compService.getRealm(), this.data.participant.data.profile["guid"], "participantList").subscribe(
+    this.dsmService.getParticipantDsmData(this.compService.getRealm(), this.data.participant.data.profile["guid"]).subscribe(
       data => {
-        if (data != null && data)
+        if (data != null) {
+          this.data.participant.participantData = data;
+          this.isParticipantProbandEmpty = this.getProbandDataId() == null;
+          if (!this.isParticipantProbandEmpty) {
+            this.probandDataId = this.getProbandDataId();
+          }
+        }
       }
     );
-    debugger;
   }
-
+  
   isFamilyMemberFieldsEmpty() {
     return !this.familyMemberFirstName || !this.familyMemberLastName || !this.familyMemberSubjectId || !this.chosenRelation;
   }
-
+  
   submitFamilyMember() {
     let shortId = this.data.participant.data.profile["hruid"];
     let payload = {
@@ -52,6 +58,7 @@ export class AddFamilyMemberComponent implements OnInit {
         collaboratorParticipantId: shortId + "_" + this.familyMemberSubjectId
       },
       copyProbandInfo: this.isCopyProbandInfo,
+      probandDataId: this.probandDataId,
       userId: this.role.userID()
     }
     this.dsmService.addFamilyMemberRequest(JSON.stringify(payload)).subscribe(
@@ -82,12 +89,21 @@ export class AddFamilyMemberComponent implements OnInit {
   }
 
   getRelations() {
-    return Statics.RELATIONS;
+    let relations = Statics.RELATIONS;
+    if (!this.isParticipantProbandEmpty) {
+      relations = relations.filter(rel => rel !== Statics.PARTICIPANT_PROBAND)
+    }
+    return relations;
   }
 
-  getProbandDataId() {
-    return this.data.participant.participantData
+  getProbandDataId() : number {
+    let ddpParticipantDataId;
+    let probandData = this.data.participant.participantData
           .filter(p => p.data.MEMBER_TYPE === Statics.PARTICIPANT_PROBAND)
           .shift();
+    if (probandData.hasOwnProperty("dataId")) {
+      ddpParticipantDataId = probandData["dataId"]
+    }
+    return ddpParticipantDataId;
   }
 }

--- a/src/app/services/dsm.service.ts
+++ b/src/app/services/dsm.service.ts
@@ -173,6 +173,16 @@ export class DSMService {
     return this.http.get( url, this.buildQueryHeader( map ) ).map( ( res: Response ) => res.json() ).catch( this.handleError );
   }
 
+  public getParticipantDsmData( realm: string, ddpParticipantId: string): Observable<any> {
+    let url = this.baseUrl + DSMService.UI + "getParticipantData";
+    let map: { name: string, value: any }[] = [];
+    let userId = this.role.userID();
+    map.push( {name: DSMService.REALM, value: realm} );
+    map.push( {name: "ddpParticipantId", value: ddpParticipantId} );
+    map.push( {name: "userId", value: userId} );
+    return this.http.get( url, this.buildQueryHeader( map ) ).map( ( res: Response ) => res.json() ).catch( this.handleError );
+  }
+
   public getSettings( realm: string, parent: string ): Observable<any> {
     let url = this.baseUrl + DSMService.UI + "displaySettings/" + realm;
     let map: { name: string, value: any }[] = [];

--- a/src/app/services/dsm.service.ts
+++ b/src/app/services/dsm.service.ts
@@ -68,7 +68,7 @@ export class DSMService {
   }
 
   public addFamilyMemberRequest( json: string ) {
-    let url = this.baseUrl + DSMService.UI + "addFamilyMember";
+    let url = this.baseUrl + DSMService.UI + "familyMember";
     return this.http.post( url, json, this.buildHeader() ).map( ( res: Response ) => res.json() ).catch( this.handleError );
   }
 


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5615

**Things to pay attention:**

- Added check box if study staff wants to copy self/proband participant's data to new family member's data.
- Added `getParticipantDsmData` method, which sends request to update all data of this participant, adding this method became necessary to determine has participant proband data already or not.
- Updated `getRelations` method which was returning list of relations, after update it excludes `Self` option from relation if participant has already self/proband data
- Added `getProbandDataId` method which returns participant's proband data id of record in `ddp_participant_table`, used to check self/proband data exists or not, `Copy Proband Info` checkbox depend on it