### PR TITLE
DDP-5743 | Relationship ID uniqeness

### DIFF
--- a/src/app/popups/add-family-member/add-family-member.component.css
+++ b/src/app/popups/add-family-member/add-family-member.component.css
@@ -17,3 +17,12 @@
 .subject-id-info.active {
     color:red;
 }
+
+.subject-id-exists {
+    display: none;
+}
+
+.subject-id-exists.active {
+    display: block;
+    color:red;
+}

--- a/src/app/popups/add-family-member/add-family-member.component.html
+++ b/src/app/popups/add-family-member/add-family-member.component.html
@@ -31,6 +31,7 @@
           <td><b>Relationship ID</b></td>
           <td>
             <span [ngClass]="{'subject-id-info': true, 'active': subjectId.errors?.pattern}">* Add relationship id as x or x_y</span>
+            <span [ngClass]="{'subject-id-exists': true, 'active': isRelationshipIdExists()}">Relationship ID already exists</span>
             <input 
             type="text"
             maxlength="10" 
@@ -67,7 +68,7 @@
     
         <tr>
           <td>
-            <button class="btn btn-primary" [disabled]="isFamilyMemberFieldsEmpty() || subjectId.errors?.pattern" (click)="submitFamilyMember()">Submit</button>
+            <button class="btn btn-primary" [disabled]="isFamilyMemberFieldsEmpty() || subjectId.errors?.pattern || isRelationshipIdExists()" (click)="submitFamilyMember()">Submit</button>
           </td>
           <td></td>
         </tr>

--- a/src/app/popups/add-family-member/add-family-member.component.ts
+++ b/src/app/popups/add-family-member/add-family-member.component.ts
@@ -106,4 +106,16 @@ export class AddFamilyMemberComponent implements OnInit {
     }
     return ddpParticipantDataId;
   }
+
+  isRelationshipIdExists() {
+    let relationshipIds: Array<String> = this.data.participant.participantData.map(pData => {
+      let familyMemberData = pData.data;
+      if (familyMemberData.hasOwnProperty(Statics.PARTICIPANT_RELATIONSHIP_ID)) {
+        let firstUnderScore = familyMemberData[Statics.PARTICIPANT_RELATIONSHIP_ID].indexOf("_");
+        return familyMemberData[Statics.PARTICIPANT_RELATIONSHIP_ID].substring(firstUnderScore + 1);
+      }
+      return "";
+    });
+    return relationshipIds.includes(this.familyMemberSubjectId);
+  }
 }

--- a/src/app/utils/statics.ts
+++ b/src/app/utils/statics.ts
@@ -96,4 +96,5 @@ export class Statics {
 
   public static PARTICIPANT_PROBAND = "SELF";
 
+  public static PARTICIPANT_RELATIONSHIP_ID = "COLLABORATOR_PARTICIPANT_ID";
 }


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5743

Added method which checks if entered relationship id exists or not, since in DB relationship id is saved like $shortid_$relationshipId, takes substring from index of first found underscore + 1 and compares it to entered relationship id:

D7SJU4_1_3:
D7SJU4 - shortId
_ - separator between short id and relationship id
1_3 - relationship Id