### PR TITLE
add default columns for dynamic fields

### DIFF
--- a/src/app/participant-list/participant-list.component.ts
+++ b/src/app/participant-list/participant-list.component.ts
@@ -180,13 +180,7 @@ export class ParticipantListComponent implements OnInit {
         this.savedFilters = [];
         this.mrCoverPdfSettings = [];
         this.assignees.push( new Assignee( "-1", "Remove Assignee", "" ) );
-        jsonData = data;
-        if (data.defaultColumns && data.defaultColumns.length > 0) {
-          this.defaultColumns = [];
-          for (let defaultColumn of data.defaultColumns) {
-            this.defaultColumns.push(Filter[defaultColumn.value]);
-          }
-        }
+        jsonData = data;    
         this.dataSources = new Map( [
           ["data", "Participant"],
           ["p", "Participant - DSM"],
@@ -336,6 +330,17 @@ export class ParticipantListComponent implements OnInit {
         }
         if (this.settings && this.settings["TAB"]) {
           this.addTabColumns();
+        }
+        if (data.defaultColumns && data.defaultColumns.length > 0) {
+          this.defaultColumns = [];
+          for (let defaultColumn of data.defaultColumns) {
+            let filterToAdd: Filter = Filter[defaultColumn.value];
+            if (filterToAdd) {
+              this.defaultColumns.push(Filter[defaultColumn.value]);
+            } else {
+              this.addDynamicFieldDefaultColumns(defaultColumn);
+            }
+          }
         }
         this.getSourceColumnsFromFilterClass();
         if (jsonData.abstractionFields != null && jsonData.abstractionFields.length > 0) {
@@ -531,6 +536,21 @@ export class ParticipantListComponent implements OnInit {
         throw "Error - Loading display settings" + err;
       }
     );
+  }
+
+  private addDynamicFieldDefaultColumns(defaultColumn: any) {
+    outer: for (let sourceColumnGroup of Object.keys(this.sourceColumns)) {
+      for (let currentFilter of this.sourceColumns[sourceColumnGroup]) {
+        const isOurDefaultColumnTabGrouped = (currentFilter['participantColumn'] && currentFilter['participantColumn']['name']
+          && currentFilter['participantColumn']['name'] === defaultColumn.value
+          && currentFilter['participantColumn']['alias'] === 'participantData');
+        const isOurDefaultColumnTabbed = (currentFilter['columnName'] && currentFilter['columnName'] === defaultColumn.value);
+        if (isOurDefaultColumnTabGrouped || isOurDefaultColumnTabbed) {
+          this.defaultColumns.push(currentFilter);
+          break outer;
+        }
+      }
+    }
   }
 
   getQuestionOrStableId( question: QuestionDefinition ): string {

--- a/src/app/participant-list/participant-list.component.ts
+++ b/src/app/participant-list/participant-list.component.ts
@@ -539,8 +539,8 @@ export class ParticipantListComponent implements OnInit {
   }
 
   private addDynamicFieldDefaultColumns(defaultColumn: any) {
-    outer: for (let sourceColumnGroup of Object.keys(this.sourceColumns)) {
-      for (let currentFilter of this.sourceColumns[sourceColumnGroup]) {
+    outer: for (let sourceColumnGroup of Object.values(this.sourceColumns)) {
+      for (let currentFilter of sourceColumnGroup as Array<Filter>) {
         const isOurDefaultColumnTabGrouped = (currentFilter['participantColumn'] && currentFilter['participantColumn']['name']
           && currentFilter['participantColumn']['name'] === defaultColumn.value
           && currentFilter['participantColumn']['alias'] === 'participantData');

--- a/src/app/participant-list/participant-list.component.ts
+++ b/src/app/participant-list/participant-list.component.ts
@@ -544,7 +544,7 @@ export class ParticipantListComponent implements OnInit {
         const isOurDefaultColumnTabGrouped = (currentFilter['participantColumn'] && currentFilter['participantColumn']['name']
           && currentFilter['participantColumn']['name'] === defaultColumn.value
           && currentFilter['participantColumn']['alias'] === 'participantData');
-        const isOurDefaultColumnTabbed = (currentFilter['columnName'] && currentFilter['columnName'] === defaultColumn.value);
+        const isOurDefaultColumnTabbed = currentFilter['columnName'] === defaultColumn.value;
         if (isOurDefaultColumnTabGrouped || isOurDefaultColumnTabbed) {
           this.defaultColumns.push(currentFilter);
           break outer;

--- a/src/app/participant-list/participant-list.component.ts
+++ b/src/app/participant-list/participant-list.component.ts
@@ -539,16 +539,28 @@ export class ParticipantListComponent implements OnInit {
   }
 
   private addDynamicFieldDefaultColumns(defaultColumn: any) {
-    outer: for (let sourceColumnGroup of Object.values(this.sourceColumns)) {
+    let defaultColumnName: string;
+    if (defaultColumn.value.split('.').length === 2) {
+      defaultColumnName = defaultColumn.value.split('.')[1];
+    }
+    if (!defaultColumnName) {
+      return;
+    }
+    for (let sourceColumnGroup of Object.values(this.sourceColumns)) {
       for (let currentFilter of sourceColumnGroup as Array<Filter>) {
         const isOurDefaultColumnTabGrouped = (currentFilter['participantColumn'] && currentFilter['participantColumn']['name']
-          && currentFilter['participantColumn']['name'] === defaultColumn.value
-          && currentFilter['participantColumn']['alias'] === 'participantData');
-        const isOurDefaultColumnTabbed = currentFilter['columnName'] === defaultColumn.value;
-        if (isOurDefaultColumnTabGrouped || isOurDefaultColumnTabbed) {
-          this.defaultColumns.push(currentFilter);
-          break outer;
+          && currentFilter['participantColumn']['name'] === defaultColumnName
+          && currentFilter['participantColumn']['tableAlias'] === 'participantData');
+        const isOurDefaultColumnTabbed = currentFilter['columnName'] === defaultColumnName;
+        if (isOurDefaultColumnTabGrouped) {
+          let groupName = currentFilter['participantColumn']['object'];
+          if (groupName) {            
+            this.defaultColumns.push(currentFilter);
+            this.selectedColumns[groupName] = currentFilter;
+            return;
+          }
         }
+        // if (isOurDefaultColumnTabbed)
       }
     }
   }


### PR DESCRIPTION
As we are going to have default columns for each study I commented out saving selected columns and renewal of them for now, maybe we will delete in the future. Where we were filling only data in selected columns with default columns I changed it so that we fill with corresponding tableAlias. Also moved staticaly creating of defaultcolumns inside loadSettings. We need it before we have filled defaultColumns for other studies as well.